### PR TITLE
read properties file as UTF-8

### DIFF
--- a/src/main/java/org/adho/dhconvalidator/properties/PropertiesInitializerServlet.java
+++ b/src/main/java/org/adho/dhconvalidator/properties/PropertiesInitializerServlet.java
@@ -5,6 +5,7 @@
 package org.adho.dhconvalidator.properties;
 
 import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -32,7 +33,7 @@ public class PropertiesInitializerServlet extends HttpServlet {
 
       Properties properties = new Properties();
 
-      properties.load(new FileInputStream(cfg.getServletContext().getRealPath(propertiesFile)));
+      properties.load(new InputStreamReader(new FileInputStream(cfg.getServletContext().getRealPath(propertiesFile)), "UTF8"));
 
       HashMap<Object, Object> propertyBuffer = new HashMap<>();
 


### PR DESCRIPTION
this PR addresses #36. I tested locally with the properties entry
```
publicationStmt=<publicationStmt xmlns="http://www.tei-c.org/ns/1.0"><publisher>Universität Paderborn</publisher><address><addrLine>Warburger Str. 100</addrLine><addrLine>33098 Paderborn</addrLine><addrLine>Deutschland</addrLine></address></publicationStmt>
```

which resulted in proper
```xml
<publicationStmt>
    <publisher>Universität Paderborn</publisher>
    <address>
        <addrLine>Warburger Str. 100</addrLine>
        <addrLine>33098 Paderborn</addrLine>
        <addrLine>Deutschland</addrLine>
    </address>
</publicationStmt>
```