### PR TITLE
add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM jetty:alpine
 #base_url=http://adho.org/dhconvalidator-2018
 #paperProviderClass=org.adho.dhconvalidator.conftool.ConfToolClient
 #userProviderClass=org.adho.dhconvalidator.conftool.ConfToolClient
-ENV dhconvalidator_base_url=http://localhost:8080/dhconv, \
+ENV dhconvalidator_base_url=http://localhost:8080/dhconv \
     dhconvalidator_conftool_login_url=https://www.conftool.pro/dh2018/ \
     dhconvalidator_conftool_rest_url=https://www.conftool.pro/dh2018/rest.php \
     dhconvalidator_conftool_shared_pass=quae4EeCh8iepaisoay2gei9wai3Eiz5uyaig1Daisie5ho4caxab8ahraeChaiz \
@@ -23,14 +23,14 @@ ENV dhconvalidator_base_url=http://localhost:8080/dhconv, \
     dhconvalidator_image_min_resolution_height=50 \
     dhconvalidator_image_min_resolution_width=800 \
     dhconvalidator_logConversionStepOutput=false \
-    dhconvalidator_oxgarage_url=http://www.tei-c.org/ege-webservice/ \
+    dhconvalidator_oxgarage_url=https://oxgarage.tei-c.org/ege-webservice/ \
     dhconvalidator_paperProviderClass=org.adho.dhconvalidator.demo.DemoPaperProvider \
     dhconvalidator_performSchemaValidation=true \
     dhconvalidator_publicationStmt='<publicationStmt xmlns="http://www.tei-c.org/ns/1.0"><publisher>Name, Institution</publisher><address><addrLine>Street</addrLine><addrLine>City</addrLine><addrLine>Country</addrLine><addrLine>Name</addrLine></address></publicationStmt>' \
     dhconvalidator_showOnlyAcceptedPapers=false \
     dhconvalidator_showOnlyAcceptedUsers=false \
     dhconvalidator_tei_image_location=/Pictures \
-    dhconvalidator_templateFileDE=template/DH_template_DH2018_en \
+    dhconvalidator_templateFileDE=template/DH_template_DH2018_de \
     dhconvalidator_templateFileEN=template/DH_template_DH2018_en \
     dhconvalidator_templateFileES=template/DH_template_DH2018_es \
     dhconvalidator_userProviderClass=org.adho.dhconvalidator.demo.DemoUserProvider

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# First step: build the war file
+FROM gradle:5.4 as builder
+
+WORKDIR /home/gradle/dhconvalidator
+USER root:root
+COPY . . 
+RUN gradle war
+
+# step 2: run the application server
+FROM jetty:alpine
+
+#base_url=http://adho.org/dhconvalidator-2018
+#paperProviderClass=org.adho.dhconvalidator.conftool.ConfToolClient
+#userProviderClass=org.adho.dhconvalidator.conftool.ConfToolClient
+ENV dhconvalidator_base_url=http://localhost:8080/dhconv, \
+    dhconvalidator_conftool_login_url=https://www.conftool.pro/dh2018/ \
+    dhconvalidator_conftool_rest_url=https://www.conftool.pro/dh2018/rest.php \
+    dhconvalidator_conftool_shared_pass=quae4EeCh8iepaisoay2gei9wai3Eiz5uyaig1Daisie5ho4caxab8ahraeChaiz \
+    dhconvalidator_defaultSubmissionLanguage=ENGLISH \
+    dhconvalidator_encodingDesc='<encodingDesc xmlns="http://www.tei-c.org/ns/1.0"><appInfo><application ident="DHCONVALIDATOR" version="{VERSION}"><label>DHConvalidator</label></application></appInfo></encodingDesc>' \
+    dhconvalidator_html_address_generation=true \
+    dhconvalidator_html_to_xml_link=true \
+    dhconvalidator_image_min_resolution_height=50 \
+    dhconvalidator_image_min_resolution_width=800 \
+    dhconvalidator_logConversionStepOutput=false \
+    dhconvalidator_oxgarage_url=http://www.tei-c.org/ege-webservice/ \
+    dhconvalidator_paperProviderClass=org.adho.dhconvalidator.demo.DemoPaperProvider \
+    dhconvalidator_performSchemaValidation=true \
+    dhconvalidator_publicationStmt='<publicationStmt xmlns="http://www.tei-c.org/ns/1.0"><publisher>Name, Institution</publisher><address><addrLine>Street</addrLine><addrLine>City</addrLine><addrLine>Country</addrLine><addrLine>Name</addrLine></address></publicationStmt>' \
+    dhconvalidator_showOnlyAcceptedPapers=false \
+    dhconvalidator_showOnlyAcceptedUsers=false \
+    dhconvalidator_tei_image_location=/Pictures \
+    dhconvalidator_templateFileDE=template/DH_template_DH2018_en \
+    dhconvalidator_templateFileEN=template/DH_template_DH2018_en \
+    dhconvalidator_templateFileES=template/DH_template_DH2018_es \
+    dhconvalidator_userProviderClass=org.adho.dhconvalidator.demo.DemoUserProvider
+
+COPY --from=builder /home/gradle/dhconvalidator/build/libs/*.war /tmp/
+COPY entrypoint.sh /entrypoint.sh
+
+USER root:root
+RUN mkdir -p ${JETTY_BASE}/webapps/ROOT \
+    && unzip /tmp/*.war -d ${JETTY_BASE}/webapps/ROOT \
+    && chown -R jetty:jetty ${JETTY_BASE}/webapps/ROOT 
+
+USER jetty:jetty
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [ADHO/dhconvalidator](https://github.com/ADHO/dhconvalidator)
 
 The goal of the DHConvalidator is a simplification of the creation of a
-consistent [TEI] (http://www.tei-c.org) text base of Digital Humanities
+consistent [TEI](http://www.tei-c.org) text base of Digital Humanities
 (DH) conference abstracts for further processing like the generation of
 the book of abstracts. The idea was to offer the user the possibility to
 edit the final version of the submission with her tool of choice
@@ -12,8 +12,8 @@ starting with two of the most popular systems Libre Office and Microsoft
 Word. 
 
 The DHConvalidator works together with the conference management tool
-[ConfTool] (http://www.conftool.net/) and uses [OxGarage]
-(http://www.tei-c.org/oxgarage/) to do the bulk conversion.
+[ConfTool](http://www.conftool.net/) and 
+uses [OxGarage](https://oxgarage.tei-c.org/) to do the bulk conversion.
 
 The submission of the final version is composed of four steps after
 logging in:
@@ -40,8 +40,8 @@ create a WAR file yourself and extract it to a Servlet container (Jetty
 Copy the dhconvalidator.properties.example to dhconvalidator.properties
 and edit it as needed:
 - Set the ConfTool REST interface settings like URL and shared password. 
-- Set the OxGarage webservice URL (Note that the dhconvalidator
-- TEI/Stylesheets profile must be installed for the OxGarage webservice)
+- Set the OxGarage webservice URL (Note that the dhconvalidator 
+    TEI/Stylesheets profile must be installed for the OxGarage webservice)
 - Edit settings for validation, min resolution, publication statement
 - and so on.
 
@@ -57,3 +57,54 @@ the host site:
 
 To avoid cross site scripting issues the domain should be the same as
 the domain of the host site. 
+
+## Docker
+
+### Building the image
+
+With Docker installed, simply enter
+```bash
+docker build -t dhconvalidator .
+```
+
+### Running a container
+
+To run the 'dhconvalidator' image you created in the step above enter 
+```bash
+docker run -d --rm -p8080:8080 --name dhconvalidator dhconvalidator 
+```
+This will spin up a container with the default settings, making 
+the DHConvalidator instance available at `http://localhost:8080/dhconv`.
+
+#### Parameters (and default values) available to the Docker container
+
+* dhconvalidator_base_url=`http://localhost:8080/dhconv`
+* dhconvalidator_conftool_login_url=`https://www.conftool.pro/dh2018/`
+* dhconvalidator_conftool_rest_url=`https://www.conftool.pro/dh2018/rest.php`
+* dhconvalidator_conftool_shared_pass=`some_password`
+* dhconvalidator_defaultSubmissionLanguage=`ENGLISH`
+* dhconvalidator_encodingDesc=`'<encodingDesc xmlns="http://www.tei-c.org/ns/1.0"><appInfo><application ident="DHCONVALIDATOR" version="{VERSION}"><label>DHConvalidator</label></application></appInfo></encodingDesc>'`
+* dhconvalidator_html_address_generation=`true`
+* dhconvalidator_html_to_xml_link=`true`
+* dhconvalidator_image_min_resolution_height=`50`
+* dhconvalidator_image_min_resolution_width=`800`
+* dhconvalidator_logConversionStepOutput=`false`
+* dhconvalidator_oxgarage_url=`https://oxgarage.tei-c.org/ege-webservice/`
+* dhconvalidator_paperProviderClass=`org.adho.dhconvalidator.demo.DemoPaperProvider`
+* dhconvalidator_performSchemaValidation=`true`
+* dhconvalidator_publicationStmt=`'<publicationStmt xmlns="http://www.tei-c.org/ns/1.0"><publisher>Name, Institution</publisher><address><addrLine>Street</addrLine><addrLine>City</addrLine><addrLine>Country</addrLine><addrLine>Name</addrLine></address></publicationStmt>'`
+* dhconvalidator_showOnlyAcceptedPapers=`false`
+* dhconvalidator_showOnlyAcceptedUsers=`false`
+* dhconvalidator_tei_image_location=`/Pictures`
+* dhconvalidator_templateFileDE=`template/DH_template_DH2018_de`
+* dhconvalidator_templateFileEN=`template/DH_template_DH2018_en`
+* dhconvalidator_templateFileES=`template/DH_template_DH2018_es`
+* dhconvalidator_userProviderClass=`org.adho.dhconvalidator.demo.DemoUserProvider`
+
+You can overwrite the default settings via environment variables, e.g. 
+```bash
+docker run -d --rm -p8080:8080 --name dhconvalidator -e dhconvalidator_base_url=http://my.dhconvalidator.base.url dhconvalidator 
+```
+will set the base url to `http://my.dhconvalidator.base.url`. 
+
+ 

--- a/README.md
+++ b/README.md
@@ -107,4 +107,31 @@ docker run -d --rm -p8080:8080 --name dhconvalidator -e dhconvalidator_base_url=
 ```
 will set the base url to `http://my.dhconvalidator.base.url`. 
 
- 
+### Docker-compose with OxGarage sidekick
+
+`docker-compose` allows you to easily run your own dedicated OxGarage 
+instance as a sidekick to the DHConvalidator.
+
+```
+version: '3'
+
+services:
+  dhconvalidator:
+    image: dhconvalidator
+    restart: always
+    ports:
+      - "8080:8080"
+    environment:
+      dhconvalidator_base_ur: http://localhost:8080
+      dhconvalidator_oxgarage_url: http://oxgarage:8080/ege-webservice/
+  oxgarage:
+    image: teic/oxgarage
+    restart: always
+    environment:
+      WEBSERVICE_URL: http://localhost:8080/ege-webservice/ 
+    volumes:
+      - /your/path/to/TEI/P5:/usr/share/xml/tei/odd:ro
+      - /your/path/to/Stylesheets:/usr/share/xml/tei/stylesheet:ro
+``` 
+NB: You need to provide your own copy of the TEI sources and Stylesheets! (see
+https://github.com/TEIC/oxgarage for more details on how to run that container)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+cat <<EOF > ${JETTY_BASE}/webapps/ROOT/dhconvalidator.properties
+#base_url=http://adho.org/dhconvalidator-2018
+base_url=${dhconvalidator_base_url}
+conftool_login_url=${dhconvalidator_conftool_login_url}
+conftool_rest_url=${dhconvalidator_conftool_rest_url}
+conftool_shared_pass=${dhconvalidator_conftool_shared_pass}
+defaultSubmissionLanguage=${dhconvalidator_defaultSubmissionLanguage}
+encodingDesc=${dhconvalidator_encodingDesc}
+html_address_generation=${dhconvalidator_html_address_generation}
+html_to_xml_link=${dhconvalidator_html_to_xml_link}
+image_min_resolution_height=${dhconvalidator_image_min_resolution_height}
+image_min_resolution_width=${dhconvalidator_image_min_resolution_width}
+logConversionStepOutput=${dhconvalidator_logConversionStepOutput}
+oxgarage_url=${dhconvalidator_oxgarage_url}
+#paperProviderClass=org.adho.dhconvalidator.conftool.ConfToolClient
+paperProviderClass=${dhconvalidator_paperProviderClass}
+performSchemaValidation=${dhconvalidator_performSchemaValidation}
+publicationStmt=${dhconvalidator_publicationStmt}
+showOnlyAcceptedPapers=${dhconvalidator_showOnlyAcceptedPapers}
+showOnlyAcceptedUsers=${dhconvalidator_showOnlyAcceptedUsers}
+tei_image_location=${dhconvalidator_tei_image_location}
+templateFileDE=${dhconvalidator_templateFileDE}
+templateFileEN=${dhconvalidator_templateFileEN}
+templateFileES=${dhconvalidator_templateFileES}
+#userProviderClass=org.adho.dhconvalidator.conftool.ConfToolClient
+userProviderClass=${dhconvalidator_userProviderClass}
+version=1.22
+EOF
+
+# run the command given in the Dockerfile at CMD 
+exec /docker-entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # this is a Docker entrypoint script that will be executed
 # for each start of a container based on that image.
 #
@@ -5,8 +7,6 @@
 # `dhconvalidator.properties` with parameters provided
 # on the command line, e.g. 
 # `docker run -e dhconvalidator_base_url=http://my.dhconvalidator.base.url …`
-
-#!/bin/sh
 
 cat <<EOF > ${JETTY_BASE}/webapps/ROOT/dhconvalidator.properties
 #base_url=http://adho.org/dhconvalidator-2018

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,11 @@
+# this is a Docker entrypoint script that will be executed
+# for each start of a container based on that image.
+#
+# the purpose here is simply to overwrite the settings in 
+# `dhconvalidator.properties` with parameters provided
+# on the command line, e.g. 
+# `docker run -e dhconvalidator_base_url=http://my.dhconvalidator.base.url …`
+
 #!/bin/sh
 
 cat <<EOF > ${JETTY_BASE}/webapps/ROOT/dhconvalidator.properties
@@ -29,5 +37,5 @@ userProviderClass=${dhconvalidator_userProviderClass}
 version=1.22
 EOF
 
-# run the command given in the Dockerfile at CMD 
+# run the original jetty entrypoint script (from the jetty base image) 
 exec /docker-entrypoint.sh


### PR DESCRIPTION
This PR adds a Dockerfile for facilitating deployment of the DHConvalidator. It also adds appropriate information to the main README file on how to build and run that container---eventually with a dedicated OxGarage sidekick. This might affect/solve #62, #59, and #33 